### PR TITLE
Bump diagrams from 0.10.0 to 0.17.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -47,7 +47,8 @@ version = "1.1.1"
 
 [metadata]
 content-hash = "798536d4642790571d8d0653ef3190b0a2139704435b8a620667401eaa05e448"
-python-versions = "3.8.2"
+lock-version = "1.0"
+python-versions = "3.8.5"
 
 [metadata.files]
 diagrams = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@ description = "Diagram as Code"
 name = "diagrams"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "0.10.0"
+version = "0.17.0"
 
 [package.dependencies]
 graphviz = ">=0.13.2,<0.14.0"
@@ -46,13 +46,13 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.1.1"
 
 [metadata]
-content-hash = "8b735fff9dcb4e2d07ce352f1e3912bb1fff9f86c0cd05cec9d053e805a78213"
+content-hash = "798536d4642790571d8d0653ef3190b0a2139704435b8a620667401eaa05e448"
 python-versions = "3.8.2"
 
 [metadata.files]
 diagrams = [
-    {file = "diagrams-0.10.0-py3-none-any.whl", hash = "sha256:e4251581c3b7dca16b4c85c9f0fa7a3d2afcf5a4f847486f18c5db2947c29f57"},
-    {file = "diagrams-0.10.0.tar.gz", hash = "sha256:636edebfe884b094dcdca0611ccecaeffddfe617ed873ca5df50eb01ea4a71cd"},
+    {file = "diagrams-0.17.0-py3-none-any.whl", hash = "sha256:7fe4b0f3baa2416c5ac9cbb69bba9d1ddf6d62524a035f4e2afb3118b310fba5"},
+    {file = "diagrams-0.17.0.tar.gz", hash = "sha256:86436166fd3a9b8dddb8ccce2716f458a55614527feedcb95ae4a8cdf5b7659f"},
 ]
 graphviz = [
     {file = "graphviz-0.13.2-py2.py3-none-any.whl", hash = "sha256:241fb099e32b8e8c2acca747211c8237e40c0b89f24b1622860075d59f4c4b25"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ version = "0.0.0-dev"
 authors = ["mingrammer <mingrammer@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "3.8.2"
+python = "3.8.5"
 diagrams = "0.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,4 @@ authors = ["mingrammer <mingrammer@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "3.8.2"
-diagrams = "0.10.0"
+diagrams = "0.17.0"


### PR DESCRIPTION
Just getting in before dependabot can do it hah.

Supersedes #15

Python version bump is necessary for compatibility with the docker image... I think